### PR TITLE
Accept history ids as inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ genes:
 barcodes:
   path: /path/to/E-MTAB-4850.aggregated_filtered_counts.mtx_cols
   type: tsv
+gtf:
+  dataset_id: fe139k21xsak
 ```
 
 where in this example case the Galaxy workflow should have input labels called `matrix`,
-`genes` and `barcodes`. The paths need to exist in the local file system.
+`genes`, `barcodes` and `gtf`. The paths need to exist in the local file system, if `path` is set within an input. Alternatively to a path in the local file system, if the file is already on the Galaxy instance, the `dataset_id` of the file can be given instead, as shown for the `gtf` case here.
 
 
 

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -62,6 +62,7 @@ def get_args():
                             default=False,
                             help="Keeps histories created, they will be purged if not.")
     arg_parser.add_argument('-w', '--keep-workflow',
+                            action='store_true',
                             default=False,
                             help="Keeps workflow created, it will be purged if not.")
     args = arg_parser.parse_args()


### PR DESCRIPTION
This adds flexibility to use history elements through the dataset_ids to be used as inputs through the inputs.yaml file.

Also improves the link shown on failure.