### PR TITLE
Allow errors for specific workflow steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This setup uses bioblend to run a Galaxy workflow through the cli:
   - Galaxy workflow as JSON file (from share workflow -> download).
   - Parameters dictionary as JSON
   - Input files defined in YAML
+  - Steps with allowed errors in YAML (optional)
   - History name (optional)
 
 # Galaxy workflow
@@ -64,5 +65,23 @@ gtf:
 where in this example case the Galaxy workflow should have input labels called `matrix`,
 `genes`, `barcodes` and `gtf`. The paths need to exist in the local file system, if `path` is set within an input. Alternatively to a path in the local file system, if the file is already on the Galaxy instance, the `dataset_id` of the file can be given instead, as shown for the `gtf` case here.
 
+# Steps with allowed errors
+
+This optional YAML file indicates the executor which steps are allowed to fail without the overal execution being considered
+failed and hence retrieving result files anyway. This is to make room to the fact that on a production setup, there might
+be border conditions on datasets that could produce acceptable failures.
+
+The structure of the file relies on the labels for steps used in the workflow and parameters files
+
+```yaml
+step_label_x:
+  - any
+step_label_z:
+  - 1
+  - 43
+```
+
+The above example means that the step with label `step_label_x` can fail with any error code, whereas step with label
+`step_label_z` will only be allowed to fail with codes 1 or 43.
 
 

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -452,7 +452,7 @@ def main():
         wf_from_json = read_json_file(args.workflow)
         param_data = read_json_file(args.parameters)
         inputs_data = read_yaml_file(args.yaml_inputs_path)
-        allowed_error_states = {}
+        allowed_error_states = {'tools': {}, 'datasets': set()}
         if args.allowed_errors is not None:
             allowed_error_states = \
                 process_allowed_errors(read_yaml_file(args.allowed_errors), wf_from_json)

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -391,7 +391,8 @@ def main():
 
         # Create new history to run workflow
         logging.info('Create new history to run workflow ...')
-        history = gi.histories.create_history(name=args.history)
+        if num_inputs > 0:
+            history = gi.histories.create_history(name=args.history)
 
         # get saved workflow defined in the galaxy instance
         logging.info('Workflow setup ...')
@@ -471,7 +472,8 @@ def main():
         if not args.keep_histories:
             logging.info('Deleting histories...')
             gi.histories.delete_history(results['history_id'], purge=True)
-            gi.histories.delete_history(history['id'], purge=True)
+            if num_inputs > 0:
+                gi.histories.delete_history(history['id'], purge=True)
             logging.info('Histories purged...')
 
         if not args.keep_workflow:


### PR DESCRIPTION
We have some workflows where we need to allow errors to occur but still consider the pipeline as correctly executed (for instance in the case of scanpy, where certain resolutions won't find more than one cluster and as such marker genes will fail to be computed). This introduces the ability to mark steps of the workflow as admissible for errors.