### PR TITLE
Consider paused jobs due to previous errors

### DIFF
--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -414,7 +414,7 @@ def completion_state(gi, history, allowed_error_states, wait_for_resubmission=Tr
 
     if completed_state:
         # add all paused jobs to allowed_error_states or fail if jobs are paused that are not allowed
-        for dataset_id in history['state_ids']['pause']:
+        for dataset_id in history['state_ids']['paused']:
             dataset = gi.datasets.show_dataset(dataset_id)
             job = gi.jobs.show_job(dataset['creating_job'])
             if job['tool_id'] in allowed_error_states['tools']:

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -565,7 +565,19 @@ def main():
         results_hid = gi.histories.show_history(results['history_id'])
         state = results_hid['state']
 
-        # wait until the jobs are completed
+        # wait until workflow invocation is fully scheduled, cancelled of failed
+        while True:
+            invocation = gi.workflows.show_invocation(workflow_id=results['workflow_id'], invocation_id=results['id'])
+            if invocation['state'] in ['scheduled', 'cancelled', 'failed']:
+                # These are the terminal states of the invocation process. Scheduled means that all jobs needed for the
+                # workflow have been scheduled, not that the workflow is finished. However, there is no point in
+                # checking completion through history elements if this hasn't happened yet.
+                logging.info("Workflow invocation has entered a terminal state: {}".format(invocation['state']))
+                logging.info("Proceeding to check individual jobs state to determine completion or failure...")
+                break
+            time.sleep(10)
+
+        # wait until the jobs are completed, once workflow scheduling is done.
         logging.debug("Got state: {}".format(state))
         while True:
             logging.debug("Got state: {}".format(state))

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -425,9 +425,9 @@ def completion_state(gi, history, allowed_error_states, wait_for_resubmission=Tr
                          .format(job['tool_id']))
             error_state = True
         # display state of jobs in history:
-        logging.info("Workflow seems to be completed, states are:")
+        logging.info("Workflow run has completed, job counts per states are:")
         for state, count in history['state_details'].items():
-            logging.info("State: {} - Count: {}".format(state, count))
+            logging.info("{}: {}".format(state, count))
 
     return error_state, completed_state
 

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -424,6 +424,10 @@ def completion_state(gi, history, allowed_error_states, wait_for_resubmission=Tr
             logging.info("Tool {} is not marked as allowed to fail, but is paused due to a previous tool failure."
                          .format(job['tool_id']))
             error_state = True
+        # display state of jobs in history:
+        logging.info("Workflow seems to be completed, states are:")
+        for state, count in history['state_details'].items():
+            logging.info("State: {} - Count: {}".format(state, count))
 
     return error_state, completed_state
 


### PR DESCRIPTION
This PR resolves some few issues found when running all the SC datasets:

- Corrects the way that we wait for workflows and jobs are waited for, making sure that we only check jobs once workflow invocation has finished.
- Considers paused jobs after a previous failed step as part of those that should be considered as done.