### PR TITLE
Check that there are finished jobs and not only that everything is non-terminal

### DIFF
--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -406,11 +406,15 @@ def completion_state(gi, history, allowed_error_states, wait_for_resubmission=Tr
     # error, ok, paused or failed_metadata.
     terminal_states = ['error', 'ok', 'paused', 'failed_metadata']
     non_terminal_datasets_count = 0
+    terminal_datasets_count = 0
     for state, count in history['state_details'].items():
         if state not in terminal_states:
             non_terminal_datasets_count += count
+        if state in terminal_states:
+            terminal_datasets_count += count
 
-    completed_state = (non_terminal_datasets_count == 0)
+    # We add the terminal_datasets_count to avoid falling here when all job states are in zero.
+    completed_state = (non_terminal_datasets_count == 0 and terminal_datasets_count > 0)
 
     if completed_state:
         # add all paused jobs to allowed_error_states or fail if jobs are paused that are not allowed


### PR DESCRIPTION
This PR fixes this issue, which sometimes is encountered on slow setups:

```
15-06-19 09:31:18 - Workflow run has completed, job counts per states are:
15-06-19 09:31:18 - paused: 0
15-06-19 09:31:18 - ok: 0
15-06-19 09:31:18 - failed_metadata: 0
15-06-19 09:31:18 - upload: 0
15-06-19 09:31:18 - discarded: 0
15-06-19 09:31:18 - running: 0
15-06-19 09:31:18 - setting_metadata: 0
15-06-19 09:31:18 - error: 0
15-06-19 09:31:18 - new: 0
15-06-19 09:31:18 - queued: 0
15-06-19 09:31:18 - empty: 0
```

@pinin4fjords please accept when you see most things that were failing due to this passing. Thanks