### PR TITLE
Resubmissions allowed errors turn around

### DIFF
--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -50,8 +50,8 @@ def get_args():
                             required=True,
                             help='Workflow to run')
     arg_parser.add_argument('-P', '--parameters',
-                            default='',
-                            required=True,
+                            default=None,
+                            required=False,
                             help='parameters file, by default json')
     arg_parser.add_argument('--parameters-yaml',
                             default=False,
@@ -100,7 +100,10 @@ def main():
 
         # Load workflows, inputs and parameters
         wf_from_json = read_json_file(args.workflow)
-        param_data = read_yaml_file(args.parameters) if args.parameters_yaml else read_json_file(args.parameters)
+        if args.parameters:
+            param_data = read_yaml_file(args.parameters) if args.parameters_yaml else read_json_file(args.parameters)
+        else:
+            param_data = dict()
         inputs_data = read_yaml_file(args.yaml_inputs_path)
         allowed_error_states = {'tools': {}, 'datasets': set()}
         if args.allowed_errors is not None:

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -163,6 +163,8 @@ def load_input_files(gi, inputs, workflow, history):
       type:
     input_label_c:
       dataset_id:
+    input_label_d:
+      collection_id:
 
     this makes it extensible to support
     :param gi: the galaxy instance (API object)
@@ -188,6 +190,11 @@ def load_input_files(gi, inputs, workflow, history):
             inputs_for_invoke[step] = {
                 'id': inputs[step_data['label']]['dataset_id'],
                 'src': 'hda'
+            }
+        elif step_data['label'] in inputs and 'collection_id' in inputs[step_data['label']]:
+            inputs_for_invoke[step] = {
+                'id': inputs[step_data['label']]['collection_id'],
+                'src': 'hdca'
             }
         elif step_data['label'] in inputs and not isinstance(inputs[step_data['label']], Mapping):
             # We are in the presence of a simple parameter input

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -90,8 +90,8 @@ def download_results(gi, history_id, output_dir, allowed_error_states, use_names
     used_names = set()
     for dataset in datasets:
         if dataset['type'] == 'file':
-            if dataset['id'] in allowed_error_states['datasets']:
-                logging.info('Skipping download of {} as it is an allowed failure.'
+            if dataset['state'] == 'error' and dataset['id'] in allowed_error_states['datasets']:
+                logging.info('Skipping download of failed {} as it is an allowed failure.'
                              .format(dataset['name']))
                 continue
             if use_names and dataset['name'] is not None and dataset['name'] not in used_names:
@@ -104,8 +104,8 @@ def download_results(gi, history_id, output_dir, allowed_error_states, use_names
                                              use_default_filename=True)
         elif dataset['type'] == 'collection':
             for ds_in_coll in dataset['elements']:
-                if ds_in_coll['object']['id'] in allowed_error_states['datasets']:
-                    logging.info('Skipping download of {} as it is an allowed failure.'
+                if ds_in_coll['object']['state'] == 'error' and ds_in_coll['object']['id'] in allowed_error_states['datasets']:
+                    logging.info('Skipping download of failed {} as it is an allowed failure.'
                                  .format(ds_in_coll['object']['name']))
                     continue
                 if use_names and ds_in_coll['object']['name'] is not None \


### PR DESCRIPTION
This PR aims to fix #22 but it also adds (as I needed for my tests):

- Make the parameters file optional (in case you want to send over a workflow with its default parameters untouched).
- Support collections initially as inputs through collection identifiers.

Regarding the clash between allowed errors and resubmissions, I have changed the order in which this is checked, so that by the default we allow the instance to recover from the error and wait for the resubmission to change the state of the dataset before labeling as an allowed error dataset. Also, we only skip download on datasets that are marked as allowed errors if the are in an error state.

I still think that there is a chance that datasets get caught like this....