### PR TITLE
Partial support for subworkflows

### DIFF
--- a/generate_params_from_workflow.py
+++ b/generate_params_from_workflow.py
@@ -82,6 +82,11 @@ def main():
             if str(value['label']) != 'None':
                 step_id = key
                 step_name = value['label']
+                # check for nested workflows
+                # don't need to extract anything as all parameters in nested wfs
+                # are set explicitly from the outer workflow
+                if show_wf['steps'][step_id]['type'] == 'subworkflow':
+                    continue
                 content = show_wf['steps'][step_id]['tool_inputs']
                 if 'parameter_type' in content:
                     # treat simple input parameters differently

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -194,8 +194,7 @@ def main():
 
         # Produce tool versions file
         produce_versions_file(gi=gi, workflow_from_json=wf_from_json,
-                              path="{}/software_versions_galaxy.txt".format(args.output_dir),
-                              tools_dict=tools_dict)
+                              path="{}/software_versions_galaxy.txt".format(args.output_dir))
 
         # wait for a little while and check if the status is ok
         logging.info("Waiting for results to be available...")
@@ -294,5 +293,4 @@ def main():
 
 if __name__ == '__main__':
     main()
-
 

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -195,7 +195,7 @@ def main():
         # Produce tool versions file
         produce_versions_file(gi=gi, workflow_from_json=wf_from_json,
                               table_path="{}/software_versions_galaxy.txt".format(args.output_dir))
-
+        
         # wait for a little while and check if the status is ok
         logging.info("Waiting for results to be available...")
         logging.info("...in the mean time, you can check {}/histories/view?id={} for progress."

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -16,7 +16,7 @@ File inputs.yaml must contain paths to all input labels in the workflow.
 """
 
 import argparse
-import os.path
+from os import path, remove
 from sys import exit
 from bioblend.galaxy import GalaxyInstance
 from bioblend import ConnectionError
@@ -193,8 +193,12 @@ def main():
             results = state.results
 
         # Produce tool versions file
+        tool_table_path = "{}/software_versions_galaxy.txt".format(args.output_dir)
+        # remove file if exists already
+        if path.exists(tool_table_path):
+            remove(tool_table_path)
         produce_versions_file(gi=gi, workflow_from_json=wf_from_json,
-                              path="{}/software_versions_galaxy.txt".format(args.output_dir))
+                              path=tool_table_path)
 
         # wait for a little while and check if the status is ok
         logging.info("Waiting for results to be available...")

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -193,7 +193,6 @@ def main():
             results = state.results
 
         # Produce tool versions file
-        tools_dict = []
         produce_versions_file(gi=gi, workflow_from_json=wf_from_json,
                               path="{}/software_versions_galaxy.txt".format(args.output_dir),
                               tools_dict=tools_dict)
@@ -295,6 +294,5 @@ def main():
 
 if __name__ == '__main__':
     main()
-
 
 

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -193,8 +193,10 @@ def main():
             results = state.results
 
         # Produce tool versions file
+        tools_dict = []
         produce_versions_file(gi=gi, workflow_from_json=wf_from_json,
-                              path="{}/software_versions_galaxy.txt".format(args.output_dir))
+                              path="{}/software_versions_galaxy.txt".format(args.output_dir),
+                              tools_dict=tools_dict)
 
         # wait for a little while and check if the status is ok
         logging.info("Waiting for results to be available...")

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -194,7 +194,7 @@ def main():
 
         # Produce tool versions file
         produce_versions_file(gi=gi, workflow_from_json=wf_from_json,
-                              path="{}/software_versions_galaxy.txt".format(args.output_dir))
+                              table_path="{}/software_versions_galaxy.txt".format(args.output_dir))
 
         # wait for a little while and check if the status is ok
         logging.info("Waiting for results to be available...")

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -193,12 +193,8 @@ def main():
             results = state.results
 
         # Produce tool versions file
-        tool_table_path = "{}/software_versions_galaxy.txt".format(args.output_dir)
-        # remove file if exists already
-        if path.exists(tool_table_path):
-            remove(tool_table_path)
         produce_versions_file(gi=gi, workflow_from_json=wf_from_json,
-                              path=tool_table_path)
+                              path="{}/software_versions_galaxy.txt".format(args.output_dir))
 
         # wait for a little while and check if the status is ok
         logging.info("Waiting for results to be available...")

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -402,30 +402,30 @@ def process_allowed_errors(allowed_errors_dict, wf_from_json):
 
     return allowed_errors_state
 
-def produce_versions_file(gi, workflow_from_json, path, tools_dict=[]):
+def produce_versions_file(gi, workflow_from_json, table_path, tools_dict=[]):
     """
     Produces a tool versions file for the workflow run.
 
     :param gi:
     :param workflow_from_json:
-    :param path: path where to save the versions file
+    :param table_path: path where to save the versions file
     :param tools_dict: list of tools used in the workflow
     :return:
     """
     # remove file if exists already; but not in recursive case
-    if path.exists(path) and tools_dict:
-        remove(path)
+    if os.path.exists(table_path) and tools_dict:
+        os.remove(table_path)
 
-    with open(file=path, mode="a") as f:
+    with open(file=table_path, mode="a") as f:
         # write header only if file is empty
-        if os.stat(path).st_size == 0:
+        if os.stat(table_path).st_size == 0:
             f.write("\t".join(["Analysis", "Software", "Version", "Citation"])+"\n")
 
         for key, step in sorted(workflow_from_json['steps'].items(), reverse=True):
             # parse sub-workflows recursively
             if "subworkflow" in step.keys():
                 subworkflow = step['subworkflow']
-                produce_versions_file(gi, subworkflow, path, tools_dict)
+                produce_versions_file(gi, subworkflow, table_path, tools_dict)
                 # subworkflows don't have meaningful tool ids
                 continue
             # Input steps won't have tool ids, and we only need each tool once.

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -412,6 +412,10 @@ def produce_versions_file(gi, workflow_from_json, path, tools_dict=[]):
     :param tools_dict: list of tools used in the workflow
     :return:
     """
+    # remove file if exists already; but not in recursive case
+    if path.exists(tool_table_path) and tools_dict:
+        remove(tool_table_path)
+
     with open(file=path, mode="a") as f:
         # write header only if file is empty
         if os.stat(path).st_size == 0:

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -402,7 +402,7 @@ def process_allowed_errors(allowed_errors_dict, wf_from_json):
 
     return allowed_errors_state
 
-def produce_versions_file(gi, workflow_from_json, path, tools_dict):
+def produce_versions_file(gi, workflow_from_json, path, tools_dict=[]):
     """
     Produces a tool versions file for the workflow run.
 

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -413,8 +413,8 @@ def produce_versions_file(gi, workflow_from_json, path, tools_dict=[]):
     :return:
     """
     # remove file if exists already; but not in recursive case
-    if path.exists(tool_table_path) and tools_dict:
-        remove(tool_table_path)
+    if path.exists(path) and tools_dict:
+        remove(path)
 
     with open(file=path, mode="a") as f:
         # write header only if file is empty

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -413,7 +413,7 @@ def produce_versions_file(gi, workflow_from_json, table_path, tools_dict=[]):
     :return:
     """
     # remove file if exists already; but not in recursive case
-    if os.path.exists(table_path) and tools_dict:
+    if os.path.exists(table_path) and not tools_dict:
         os.remove(table_path)
 
     with open(file=table_path, mode="a") as f:


### PR DESCRIPTION
- This PR addresses a problem with nested workflows when building a parameter file. 
Since the inner workflows receive all their parameters from the outer workflow, 
these parameters will already be present in the JSON file. Thus, we can safely skip inner workflows. 

- It also adds functionality to parse nested workflows and extract tool information from the subworkflows. 