### PR TITLE
Fail on failed of cancelled/failed invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Currently produced error codes:
 | Error code | Description |
 |------------|-------------|
 | 3          | Connection error during history deletion, this is not a critical error as most probably the history will get deleted by the server. A file named histories_to_check.txt is created in the working directory. Data will have been downloaded by then. |
+| 4          | Workflow scheduling cancelled at the Galaxy instance. Currently no downloads or clean-up done. This is probably an error that you cannot recover automatically from. |
+| 5          | Workflow scheduling failed at the Galaxy instance. Currently no downloads or clean-up done. This is probably an error that you cannot recover automatically from. |
 
 
 

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -210,11 +210,19 @@ def main():
         # wait until workflow invocation is fully scheduled, cancelled of failed
         while True:
             invocation = gi.workflows.show_invocation(workflow_id=results['workflow_id'], invocation_id=results['id'])
-            if invocation['state'] in ['scheduled', 'cancelled', 'failed']:
-                # These are the terminal states of the invocation process. Scheduled means that all jobs needed for the
-                # workflow have been scheduled, not that the workflow is finished. However, there is no point in
-                # checking completion through history elements if this hasn't happened yet.
-                logging.info("Workflow invocation has entered a terminal state: {}".format(invocation['state']))
+            # These are the terminal states of the invocation process. Scheduled means that all jobs needed for the
+            # workflow have been scheduled, not that the workflow is finished. However, there is no point in
+            # checking completion through history elements if this hasn't happened yet.
+            if invocation['state'] == 'cancelled':
+                logging.error("Invocation was cancelled... exiting.")
+                logging.info(f"Invocation id: {invocation['id']}")
+                exit(4)
+            if invocation['state'] == 'failed':
+                logging.error("Invocation was failed... exiting.")
+                logging.info(f"Invocation id: {invocation['id']}")
+                exit(5)
+            if invocation['state'] == 'scheduled':
+                logging.info(f"Workflow invocation has entered a terminal state: {invocation['state']}")
                 logging.info("Proceeding to check individual jobs state to determine completion or failure...")
                 break
             time.sleep(10)

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -218,7 +218,7 @@ def main():
                 logging.info(f"Invocation id: {invocation['id']}")
                 exit(4)
             if invocation['state'] == 'failed':
-                logging.error("Invocation was failed... exiting.")
+                logging.error("Invocation failed... exiting.")
                 logging.info(f"Invocation id: {invocation['id']}")
                 exit(5)
             if invocation['state'] == 'scheduled':


### PR DESCRIPTION
Currently the setup finishes without error if the workflow scheduling fails or is cancelled, this PR fixes that.