### PR TITLE
Feature/check md5 changes

### DIFF
--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -134,7 +134,9 @@ def main():
         gi = GalaxyInstance(ins['url'], key=ins['key'])
         validate_dataset_id_exists(gi, inputs_data)
 
-        state = ExecutionState.start(path=args.state_file)
+        state = ExecutionState.start(path=args.state_file,
+                                     workflow_path=args.workflow,
+                                     parameters_path=args.parameters)
 
         # Create new history to run workflow
         if state.input_history is None:

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -134,8 +134,9 @@ def main():
         gi = GalaxyInstance(ins['url'], key=ins['key'])
         validate_dataset_id_exists(gi, inputs_data)
 
-        state = ExecutionState.start(path=args.state_file,
+        state = ExecutionState.start(state_path=args.state_file,
                                      workflow_path=args.workflow,
+                                     inputs_path=args.yaml_inputs_path,
                                      parameters_path=args.parameters)
 
         # Create new history to run workflow

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -464,7 +464,7 @@ class ExecutionState(object):
         if ExecutionState.get_file_md5(inputs_path) != self.inputs_hex:
             logging.warning("There are changes in the input file. "
                             "Delete .pickle file if you want to run workflow from the beginning.")
-        if ExecutionState.get_file_md5(parameters_path) != self.parameters_hex:
+        if (parameters_path is not None) and (ExecutionState.get_file_md5(parameters_path) != self.parameters_hex):
             logging.warning("There are changes in the parameters file. "
                             "Delete .pickle file if you want to run workflow from the beginning.")
 
@@ -480,7 +480,7 @@ class ExecutionState(object):
                 with open(state_path, mode='rb') as d:
                     es = pickle.load(d)
                     if type(es) is ExecutionState:
-                        # Check if there are any changes in the parameters and workflow files
+                        # Check if there are any changes in the parameters, inputs and workflow files
                         es.check_md5(workflow_path, inputs_path, parameters_path)
                         return es
                     else:

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -487,6 +487,7 @@ class ExecutionState(object):
                         logging.warning("The provided file {} does not have an ExecutionState object serialised".format(state_path))
             except Exception:
                 logging.warning("Could not read serialized file {}.".format(state_path))
+                logging.exception("message")
         return ExecutionState(state_path, workflow_path, inputs_path, parameters_path)
 
     def save_state(self):


### PR DESCRIPTION
#28 Added saving and checking file's md5 functionality to [ExecutionState](https://github.com/ebi-gene-expression-group/galaxy-workflow-executor/blob/97908569dab3d15c7ef13b52ffceecb9e294efcc/wfexecutor/__init__.py#L444) class. Decided to go with ["warning"](https://github.com/ebi-gene-expression-group/galaxy-workflow-executor/issues/28#issuecomment-1190311558) option. 

I am not very sure if `check_md5` function (line 460 __init__.py) could have been written in more readable way.
Also wonder if I should have added "Yes/No" question after ["warning"](https://github.com/ebi-gene-expression-group/galaxy-workflow-executor/issues/28#issuecomment-1190311558). 