### PR TITLE
Adding support for results upload to library

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ The above example means that the step with label `step_label_x` can fail with an
 
 # Results
 
-All workflow outputs that were marked in the workflow to be shown will be downloaded to the specified results directory,
-hidden results will be ignored. Unless specified, histories (with its contents) and workflows will be deleted from the instance.
+All workflow outputs that were marked in the workflow to be shown will either be downloaded (if `-l` or `--library-name` is not specified) to the specified results directory,
+or results will be uploaded to the specified library, in both cases hidden results will be ignored and unless specified, histories (with its contents) and workflows will be deleted from the instance.
 
 # Toy example
 

--- a/generate_params_from_workflow.py
+++ b/generate_params_from_workflow.py
@@ -22,6 +22,7 @@ Output parameter file will be appended with workflow_filename as workflow_filena
 import argparse
 import os.path
 from bioblend.galaxy import GalaxyInstance
+from bioblend.galaxy.dataset_collections import DatasetCollectionClient
 
 from wfexecutor import *
 

--- a/generate_params_from_workflow.py
+++ b/generate_params_from_workflow.py
@@ -22,7 +22,6 @@ Output parameter file will be appended with workflow_filename as workflow_filena
 import argparse
 import os.path
 from bioblend.galaxy import GalaxyInstance
-from bioblend.galaxy.dataset_collections import DatasetCollectionClient
 
 from wfexecutor import *
 

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -254,7 +254,14 @@ def main():
         # Upload results to Library
         if args.library_name:
             logging.info('Uploading results to Library')
-            lib_id = gi.libraries.get_libraries(name=args.library_name)[0]['id']
+            lib = gi.libraries.get_libraries(name=args.library_name)
+
+            if lib == []:
+                lib = gi.libraries.create_library(name=args.library_name, description="Generated from galaxy-workflow-executor")
+                lib_id = lib['id']
+            else:
+                lib_id = lib[0]['id']
+                   
             if lib_id:
                 export_results_to_data_library(gi=gi, history_id=results['history_id'], lib_id=lib_id, allowed_error_states=allowed_error_states)
             else:

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -40,7 +40,6 @@ def get_args():
                             required=True,
                             help='Path to Yaml detailing inputs')
     arg_parser.add_argument('-o', '--output-dir',
-                            # default=os.getcwd(),
                             help='Path to output directory')
     arg_parser.add_argument('-H', '--history',
                             default='',

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -78,6 +78,11 @@ def get_args():
                             action='store_true',
                             default=False,
                             help="Keeps workflow created, it will be purged if not.")
+    arg_parser.add_argument('-l', '--library-name',
+                            required=False,
+                            default=None,
+                            help="Upload results to data library with the name specified."
+                            )
     arg_parser.add_argument('--publish', action='store_true',
                             default=False, help="Keep result history and make it public/accesible.")
     arg_parser.add_argument('--accessible', action='store_true',
@@ -246,14 +251,25 @@ def main():
             results_hid = gi.histories.show_history(results['history_id'])
             state = results_hid['state']
 
+        # Upload results to Library
+        if args.library_name:
+            logging.info('Uploading results to Library')
+            lib_id = gi.libraries.get_libraries(name=args.library_name)[0]['id']
+            if lib_id:
+                export_results_to_data_library(gi=gi, history_id=results['history_id'], lib_id=lib_id, allowed_error_states=allowed_error_states)
+            else:
+                logging.error('Library {} not found, results not uploaded to library'.args.library_name)
+
+
         # Download results
-        logging.info('Downloading results ...')
-        download_results(gi, history_id=results['history_id'],
-                         output_dir=args.output_dir, allowed_error_states=allowed_error_states,
-                         use_names=True)
-        logging.info('Results available.')
-        logging.info('Deleting state file {}'.format(args.state_file))
-        os.unlink(args.state_file)
+        if args.output_dir:
+            logging.info('Downloading results ...')
+            download_results(gi, history_id=results['history_id'],
+                output_dir=args.output_dir, allowed_error_states=allowed_error_states,
+                use_names=True)
+            logging.info('Results available.')
+            logging.info('Deleting state file {}'.format(args.state_file))
+            os.unlink(args.state_file)
 
         if args.publish:
             gi.histories.update_history(results['history_id'], published=True)

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -40,7 +40,7 @@ def get_args():
                             required=True,
                             help='Path to Yaml detailing inputs')
     arg_parser.add_argument('-o', '--output-dir',
-                            default=os.getcwd(),
+                            # default=os.getcwd(),
                             help='Path to output directory')
     arg_parser.add_argument('-H', '--history',
                             default='',

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -81,7 +81,7 @@ def get_args():
     arg_parser.add_argument('-l', '--library-name',
                             required=False,
                             default=None,
-                            help="Upload results to data library with the name specified."
+                            help="Upload results to data library with the name specified. Results will not be downoaded locally."
                             )
     arg_parser.add_argument('--publish', action='store_true',
                             default=False, help="Keep result history and make it public/accesible.")

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -87,8 +87,6 @@ def get_args():
                             default=False, help="Keep result history and make it public/accesible.")
     arg_parser.add_argument('--accessible', action='store_true',
                             default=False, help="Keep result history and make it accessible via link only.")
-    arg_parser.add_argument('--do-not-download-results', action='store_true',
-                            default=False, help="Will skip downloading results.")
     args = arg_parser.parse_args()
     return args
 
@@ -262,9 +260,9 @@ def main():
             else:
                 logging.error('Library {} not found, results not uploaded to library'.args.library_name)
 
+        else:
+        # If library name not specied then Download results
 
-        # Download results
-        if args.do_not_download_results == False:
             logging.info('Downloading results ...')
             download_results(gi, history_id=results['history_id'],
                 output_dir=args.output_dir, allowed_error_states=allowed_error_states,

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -40,6 +40,7 @@ def get_args():
                             required=True,
                             help='Path to Yaml detailing inputs')
     arg_parser.add_argument('-o', '--output-dir',
+                            default=os.getcwd(),
                             help='Path to output directory')
     arg_parser.add_argument('-H', '--history',
                             default='',

--- a/run_galaxy_workflow.py
+++ b/run_galaxy_workflow.py
@@ -87,6 +87,8 @@ def get_args():
                             default=False, help="Keep result history and make it public/accesible.")
     arg_parser.add_argument('--accessible', action='store_true',
                             default=False, help="Keep result history and make it accessible via link only.")
+    arg_parser.add_argument('--do-not-download-results', action='store_true',
+                            default=False, help="Will skip downloading results.")
     args = arg_parser.parse_args()
     return args
 
@@ -262,7 +264,7 @@ def main():
 
 
         # Download results
-        if args.output_dir:
+        if args.do_not_download_results == False:
             logging.info('Downloading results ...')
             download_results(gi, history_id=results['history_id'],
                 output_dir=args.output_dir, allowed_error_states=allowed_error_states,

--- a/run_tests_with_containers.sh
+++ b/run_tests_with_containers.sh
@@ -12,7 +12,7 @@ docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
     -e "GALAXY_CONFIG_ADMIN_USERS=$helper_user_email,admin@galaxy.org" \
     -e "NONUSE=nodejs,proftp,reports" \
     -e "GALAXY_CONFIG_ALLOW_PATH_PASTE=true" \
-    bgruening/galaxy-stable:20.09
+    bgruening/galaxy-stable:19.09
 rm -rf venv-test
 # virtualenv venv-test
 python3 -m venv venv-test

--- a/run_tests_with_containers.sh
+++ b/run_tests_with_containers.sh
@@ -12,7 +12,7 @@ docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
     -e "GALAXY_CONFIG_ADMIN_USERS=$helper_user_email,admin@galaxy.org" \
     -e "NONUSE=nodejs,proftp,reports" \
     -e "GALAXY_CONFIG_ALLOW_PATH_PASTE=true" \
-    bgruening/galaxy-stable:19.09
+    bgruening/galaxy-stable:20.09
 rm -rf venv-test
 # virtualenv venv-test
 python3 -m venv venv-test

--- a/run_tests_with_containers.sh
+++ b/run_tests_with_containers.sh
@@ -47,3 +47,9 @@ run_galaxy_workflow.py -C test/creds.yaml \
     -G test -o test_out/ -H 'test history' -W test/wf.json \
     -i test/wf_inputs.yaml -P test/wf_parameters.yaml \
     --parameters-yaml
+
+# Runs a test with data upload to datalib 
+run_galaxy_workflow.py -C test/creds.yaml \
+    -G test -l test -H 'lib test history' -W test/wf.json \
+    -i test/wf_inputs.yaml -P test/wf_parameters.yaml \
+    --parameters-yaml

--- a/run_tests_with_containers.sh
+++ b/run_tests_with_containers.sh
@@ -11,6 +11,7 @@ docker run -d -p 8080:80 -p 8021:21 -p 8022:22 \
     -e "GALAXY_CONFIG_MASTER_API_KEY=$api_key" \
     -e "GALAXY_CONFIG_ADMIN_USERS=$helper_user_email,admin@galaxy.org" \
     -e "NONUSE=nodejs,proftp,reports" \
+    -e "GALAXY_CONFIG_ALLOW_PATH_PASTE=true" \
     bgruening/galaxy-stable:19.09
 rm -rf venv-test
 # virtualenv venv-test

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         description='Execute workflows on Galaxy through the CLI',
         long_description=readme(),
         packages=find_packages(),
-        install_requires=['bioblend==0.13.0'],
+        install_requires=['bioblend==1.2.0'],
         author='Suhaib Mohammed, Pablo Moreno',
         long_description_content_type='text/markdown',
         author_email='',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         long_description=readme(),
         packages=find_packages(),
         install_requires=['bioblend==0.13.0'],
-        author='Suhaib Mohammed, Pablo Moreno',
+        author='Suhaib Mohammed, Pablo Moreno, Anil Thanki',
         long_description_content_type='text/markdown',
         author_email='',
         scripts=['run_galaxy_workflow.py', 'generate_params_from_workflow.py'],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         description='Execute workflows on Galaxy through the CLI',
         long_description=readme(),
         packages=find_packages(),
-        install_requires=['bioblend==1.2.0'],
+        install_requires=['bioblend==0.13.0'],
         author='Suhaib Mohammed, Pablo Moreno',
         long_description_content_type='text/markdown',
         author_email='',

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -179,8 +179,6 @@ def export_results_to_data_library(gi, history_id, lib_id, allowed_error_states)
             logging.info('folder_name to {}.'
                          .format(folder_name))
             
-            logging.info('history_name {}.'
-                         .format(history_name))
             
             folder = gi.libraries.get_folders(library_id=lib_id, name='/'+base_folder_name+'/'+folder_name)
 

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -121,6 +121,59 @@ def download_results(gi, history_id, output_dir, allowed_error_states, use_names
                                                  use_default_filename=True)
 
 
+def export_results_to_data_library(gi, history_id, lib_id, allowed_error_states):
+    """
+    Downloads results from a given Galaxy instance and history to a specified filesystem location.
+    :param gi: galaxy instance object
+    :param history_id: ID of the history from where results should be retrieved.
+    :param output_dir: path to where result file should be written.
+    :param allowed_error_states: dictionary with elements known to be allowed to fail.
+    :return:
+    """
+    datasets = gi.histories.show_history(history_id,
+                                         contents=True,
+                                         visible=True, details='all')
+
+    for dataset in datasets:
+        if dataset['type'] == 'file':
+            if dataset['state'] == 'error' and dataset['id'] in allowed_error_states['datasets']:
+                logging.info('Skipping upload of failed {} as it is an allowed failure.'
+                             .format(dataset['name']))
+                continue
+            if dataset['name'] is not None:
+
+                file_path = dataset['file_name']
+                folder_name = gi.histories.show_history(history_id)['name']
+                folder = gi.libraries.get_folders(library_id=lib_id, name='/'+folder_name)
+
+                if folder == []:
+                    folder = gi.libraries.gi.libraries.create_folder(library_id=lib_id, folder_name=folder_name)
+
+                folder_id = folder[0]['id']
+                uploaded_dataset = gi.libraries.upload_from_galaxy_filesystem(lib_id, file_path, folder_id=folder_id, link_data_only="copy_files", tag_using_filenames=True)
+                gi.libraries.wait_for_dataset(library_id=lib_id, dataset_id=uploaded_dataset[0]['id']) 
+                updated_dataset = gi.libraries.update_library_dataset(dataset_id=uploaded_dataset[0]['id'], name=dataset['name'])
+
+                logging.info('data uploaded updating name to {}.'
+                             .format(dataset['name']))
+                
+                gi.libraries.update_library_dataset(dataset_id=uploaded_dataset[0]['id'], name=dataset['name'])
+
+#             Adding support for data collection 
+#             elif dataset['type'] == 'collection':
+#             for ds_in_coll in dataset['elements']:
+#                 if ds_in_coll['object']['state'] == 'error' and ds_in_coll['object']['id'] in allowed_error_states['datasets']:
+#                     logging.info('Skipping upload of failed {} as it is an allowed failure.'
+#                                  .format(ds_in_coll['object']['name']))
+#                     continue
+#                 if ds_in_coll['object']['name'] is not None:
+#                     # TODO it fails here to download if it is in 'error' state
+#                     gi.datasets.download_dataset(ds_in_coll['object']['id'],
+#                                                  file_path=os.path.join(output_dir, ds_in_coll['object']['name']),
+#                                                  use_default_filename=False)
+#                     used_names.add(ds_in_coll['object']['name'])
+
+
 def set_params(json_wf, param_data):
     """
     Associate parameters to workflow steps via the step label. The result is a dictionary

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -159,55 +159,33 @@ def export_results_to_data_library(gi, history_id, lib_id, allowed_error_states)
                 
                 gi.libraries.update_library_dataset(dataset_id=uploaded_dataset[0]['id'], name=dataset['name'])
 
-#             Adding support for data collection 
         elif dataset['type'] == 'collection':
-            logging.info('collection block starts')
             
-            base_folder_name = gi.histories.show_history(history_id)['name']
-
             base_folder_name = gi.histories.show_history(history_id)['name']
             base_folder = gi.libraries.get_folders(library_id=lib_id, name='/'+base_folder_name)
 
-            logging.info('folder_name to {}.'
-             .format(base_folder_name))
-            
             if base_folder == []:
                 base_folder = gi.libraries.gi.libraries.create_folder(library_id=lib_id, folder_name=base_folder_name)
 
             folder_name = gi.dataset_collections.show_dataset_collection(dataset['id'], 'history')['name']
-
-            logging.info('folder_name to {}.'
-                         .format(folder_name))
-            
-            
             folder = gi.libraries.get_folders(library_id=lib_id, name='/'+base_folder_name+'/'+folder_name)
 
             if folder == []:
-                logging.info('if foolder block..')
-                
                 folder = gi.libraries.gi.libraries.create_folder(library_id=lib_id, folder_name=folder_name, base_folder_id=base_folder[0]['id'])
 
             folder_id = folder[0]['id']
-            logging.info('data uploaded updating name to {}.'
-                         .format(dataset['name']))
             
             for ds_in_coll in dataset['elements']:
-                logging.info('for loop')
                 
                 if ds_in_coll['object']['state'] == 'error' and ds_in_coll['object']['id'] in allowed_error_states['datasets']:
                     logging.info('Skipping upload of failed {} as it is an allowed failure.'
                              .format(ds_in_coll['object']['name']))
                     continue
                 if ds_in_coll['object']['name'] is not None:
-                    logging.info('if ds block {}.'
-                         .format(ds_in_coll['object']['name']))
                     
                     # Get dataset object for the collection element
                     dataset = gi.datasets.show_dataset(ds_in_coll['id'])
                     file_path = dataset['file_name']
-
-                    logging.info('file_path {}.'
-                         .format(file_path))
                     
                     uploaded_dataset = gi.libraries.upload_from_galaxy_filesystem(lib_id, file_path, folder_id=folder_id, link_data_only="copy_files", tag_using_filenames=True)
                     gi.libraries.wait_for_dataset(library_id=lib_id, dataset_id=uploaded_dataset[0]['id']) 

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -163,22 +163,30 @@ def export_results_to_data_library(gi, history_id, lib_id, allowed_error_states)
         elif dataset['type'] == 'collection':
             logging.info('collection block starts')
             
+            base_folder_name = gi.histories.show_history(history_id)['name']
+
+            base_folder_name = gi.histories.show_history(history_id)['name']
+            base_folder = gi.libraries.get_folders(library_id=lib_id, name='/'+base_folder_name)
+
+            if base_folder == []:
+                base_folder = gi.libraries.gi.libraries.create_folder(library_id=lib_id, folder_name=folder_name)
+
             folder_name = gi.dataset_collections.show_dataset_collection(dataset['id'], 'history')['name']
 
             logging.info('folder_name to {}.'
                          .format(folder_name))
 
             
-            history_name = gi.histories.show_history(history_id)['name']
+            
             logging.info('history_name {}.'
                          .format(history_name))
             
-            folder = gi.libraries.get_folders(library_id=lib_id, name='/'+history_name+'/'+folder_name)
+            folder = gi.libraries.get_folders(library_id=lib_id, name='/'+base_folder_name+'/'+folder_name)
 
             if folder == []:
                 logging.info('if foolder block..')
                 
-                folder = gi.libraries.gi.libraries.create_folder(library_id=lib_id, folder_name=folder_name)
+                folder = gi.libraries.gi.libraries.create_folder(library_id=lib_id, folder_name=folder_name, base_folder_id=base_folder[0]['id])
 
             folder_id = folder[0]['id']
             logging.info('data uploaded updating name to {}.'

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -161,23 +161,46 @@ def export_results_to_data_library(gi, history_id, lib_id, allowed_error_states)
 
 #             Adding support for data collection 
             elif dataset['type'] == 'collection':
+                logging.info('collection block starts')
+                
                 folder_name = gi.dataset_collections.show_dataset_collection(dataset['id'], 'history')['name']
+
+                logging.info('folder_name to {}.'
+                             .format(folder_name))
+
+                
                 history_name = gi.histories.show_history(history_id)['name']
+                logging.info('history_name {}.'
+                             .format(history_name))
+                
                 folder = gi.libraries.get_folders(library_id=lib_id, name='/'+history_name+'/'+folder_name)
 
                 if folder == []:
+                    logging.info('if foolder block..')
+                    
                     folder = gi.libraries.gi.libraries.create_folder(library_id=lib_id, folder_name=folder_name)
 
                 folder_id = folder[0]['id']
+                logging.info('data uploaded updating name to {}.'
+                             .format(dataset['name']))
+                
                 for ds_in_coll in dataset['elements']:
+                    logging.info('for loop')
+                    
                     if ds_in_coll['object']['state'] == 'error' and ds_in_coll['object']['id'] in allowed_error_states['datasets']:
                         logging.info('Skipping upload of failed {} as it is an allowed failure.'
                                  .format(ds_in_coll['object']['name']))
                         continue
                     if ds_in_coll['object']['name'] is not None:
+                        logging.info('if ds block {}.'
+                             .format(ds_in_coll['object']['name']))
+                        
                         # Get dataset object for the collection element
                         dataset = gi.datasets.show_dataset(ds_in_coll['id'])
-                        file_path = dataset['file_name']               
+                        file_path = dataset['file_name']
+
+                        logging.info('file_path {}.'
+                             .format(file_path))
                         
                         uploaded_dataset = gi.libraries.upload_from_galaxy_filesystem(lib_id, file_path, folder_id=folder_id, link_data_only="copy_files", tag_using_filenames=True)
                         gi.libraries.wait_for_dataset(library_id=lib_id, dataset_id=uploaded_dataset[0]['id']) 

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -160,54 +160,54 @@ def export_results_to_data_library(gi, history_id, lib_id, allowed_error_states)
                 gi.libraries.update_library_dataset(dataset_id=uploaded_dataset[0]['id'], name=dataset['name'])
 
 #             Adding support for data collection 
-            elif dataset['type'] == 'collection':
-                logging.info('collection block starts')
-                
-                folder_name = gi.dataset_collections.show_dataset_collection(dataset['id'], 'history')['name']
+         elif dataset['type'] == 'collection':
+            logging.info('collection block starts')
+            
+            folder_name = gi.dataset_collections.show_dataset_collection(dataset['id'], 'history')['name']
 
-                logging.info('folder_name to {}.'
-                             .format(folder_name))
+            logging.info('folder_name to {}.'
+                         .format(folder_name))
 
-                
-                history_name = gi.histories.show_history(history_id)['name']
-                logging.info('history_name {}.'
-                             .format(history_name))
-                
-                folder = gi.libraries.get_folders(library_id=lib_id, name='/'+history_name+'/'+folder_name)
+            
+            history_name = gi.histories.show_history(history_id)['name']
+            logging.info('history_name {}.'
+                         .format(history_name))
+            
+            folder = gi.libraries.get_folders(library_id=lib_id, name='/'+history_name+'/'+folder_name)
 
-                if folder == []:
-                    logging.info('if foolder block..')
-                    
-                    folder = gi.libraries.gi.libraries.create_folder(library_id=lib_id, folder_name=folder_name)
-
-                folder_id = folder[0]['id']
-                logging.info('data uploaded updating name to {}.'
-                             .format(dataset['name']))
+            if folder == []:
+                logging.info('if foolder block..')
                 
-                for ds_in_coll in dataset['elements']:
-                    logging.info('for loop')
-                    
-                    if ds_in_coll['object']['state'] == 'error' and ds_in_coll['object']['id'] in allowed_error_states['datasets']:
-                        logging.info('Skipping upload of failed {} as it is an allowed failure.'
-                                 .format(ds_in_coll['object']['name']))
-                        continue
-                    if ds_in_coll['object']['name'] is not None:
-                        logging.info('if ds block {}.'
+                folder = gi.libraries.gi.libraries.create_folder(library_id=lib_id, folder_name=folder_name)
+
+            folder_id = folder[0]['id']
+            logging.info('data uploaded updating name to {}.'
+                         .format(dataset['name']))
+            
+            for ds_in_coll in dataset['elements']:
+                logging.info('for loop')
+                
+                if ds_in_coll['object']['state'] == 'error' and ds_in_coll['object']['id'] in allowed_error_states['datasets']:
+                    logging.info('Skipping upload of failed {} as it is an allowed failure.'
                              .format(ds_in_coll['object']['name']))
-                        
-                        # Get dataset object for the collection element
-                        dataset = gi.datasets.show_dataset(ds_in_coll['id'])
-                        file_path = dataset['file_name']
+                    continue
+                if ds_in_coll['object']['name'] is not None:
+                    logging.info('if ds block {}.'
+                         .format(ds_in_coll['object']['name']))
+                    
+                    # Get dataset object for the collection element
+                    dataset = gi.datasets.show_dataset(ds_in_coll['id'])
+                    file_path = dataset['file_name']
 
-                        logging.info('file_path {}.'
-                             .format(file_path))
-                        
-                        uploaded_dataset = gi.libraries.upload_from_galaxy_filesystem(lib_id, file_path, folder_id=folder_id, link_data_only="copy_files", tag_using_filenames=True)
-                        gi.libraries.wait_for_dataset(library_id=lib_id, dataset_id=uploaded_dataset[0]['id']) 
-                        updated_dataset = gi.libraries.update_library_dataset(dataset_id=uploaded_dataset[0]['id'], name=dataset['name'])
+                    logging.info('file_path {}.'
+                         .format(file_path))
+                    
+                    uploaded_dataset = gi.libraries.upload_from_galaxy_filesystem(lib_id, file_path, folder_id=folder_id, link_data_only="copy_files", tag_using_filenames=True)
+                    gi.libraries.wait_for_dataset(library_id=lib_id, dataset_id=uploaded_dataset[0]['id']) 
+                    updated_dataset = gi.libraries.update_library_dataset(dataset_id=uploaded_dataset[0]['id'], name=dataset['name'])
 
-                        logging.info('data uploaded updating name to {}.'
-                             .format(dataset['name']))
+                    logging.info('data uploaded updating name to {}.'
+                         .format(dataset['name']))
 
 
 def set_params(json_wf, param_data):

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -274,10 +274,13 @@ def load_input_files(gi, inputs, workflow, history):
             # We are in the presence of a simple parameter input
             inputs_for_invoke[step] = inputs[step_data['label']]
         elif step_data['label'] in inputs and 'library_id' in inputs[step_data['label']]:
-             inputs_for_invoke[step] = {
-                 'id': inputs[step_data['label']]['library_id'],
-                 'src': 'ldda'
-             }
+            upload_res = gi.histories.copy_dataset(history_id=history['id'],
+                                              dataset_id=inputs[step_data['label']]['library_id'],
+                                              source="library")
+            inputs_for_invoke[step] = {
+                 'id': upload_res['id'],
+                 'src': 'hda'
+            }
         else:
             raise ValueError("Label '{}' is not present in inputs yaml".format(step_data['label']))
 

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -168,15 +168,16 @@ def export_results_to_data_library(gi, history_id, lib_id, allowed_error_states)
             base_folder_name = gi.histories.show_history(history_id)['name']
             base_folder = gi.libraries.get_folders(library_id=lib_id, name='/'+base_folder_name)
 
+            logging.info('folder_name to {}.'
+             .format(base_folder_name))
+            
             if base_folder == []:
-                base_folder = gi.libraries.gi.libraries.create_folder(library_id=lib_id, folder_name=folder_name)
+                base_folder = gi.libraries.gi.libraries.create_folder(library_id=lib_id, folder_name=base_folder_name)
 
             folder_name = gi.dataset_collections.show_dataset_collection(dataset['id'], 'history')['name']
 
             logging.info('folder_name to {}.'
                          .format(folder_name))
-
-            
             
             logging.info('history_name {}.'
                          .format(history_name))

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -160,7 +160,7 @@ def export_results_to_data_library(gi, history_id, lib_id, allowed_error_states)
                 gi.libraries.update_library_dataset(dataset_id=uploaded_dataset[0]['id'], name=dataset['name'])
 
 #             Adding support for data collection 
-         elif dataset['type'] == 'collection':
+        elif dataset['type'] == 'collection':
             logging.info('collection block starts')
             
             folder_name = gi.dataset_collections.show_dataset_collection(dataset['id'], 'history')['name']

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -186,7 +186,7 @@ def export_results_to_data_library(gi, history_id, lib_id, allowed_error_states)
             if folder == []:
                 logging.info('if foolder block..')
                 
-                folder = gi.libraries.gi.libraries.create_folder(library_id=lib_id, folder_name=folder_name, base_folder_id=base_folder[0]['id])
+                folder = gi.libraries.gi.libraries.create_folder(library_id=lib_id, folder_name=folder_name, base_folder_id=base_folder[0]['id'])
 
             folder_id = folder[0]['id']
             logging.info('data uploaded updating name to {}.'

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -274,9 +274,8 @@ def load_input_files(gi, inputs, workflow, history):
             # We are in the presence of a simple parameter input
             inputs_for_invoke[step] = inputs[step_data['label']]
         elif step_data['label'] in inputs and 'library_id' in inputs[step_data['label']]:
-            upload_res = gi.histories.copy_dataset(history_id=history['id'],
-                                              dataset_id=inputs[step_data['label']]['library_id'],
-                                              source="library")
+            upload_res = gi.histories.upload_dataset_from_library(history_id=history['id'], 
+                                                                  lib_dataset_id=inputs[step_data['label']]['library_id'])
             inputs_for_invoke[step] = {
                  'id': upload_res['id'],
                  'src': 'hda'

--- a/wfexecutor/__init__.py
+++ b/wfexecutor/__init__.py
@@ -184,7 +184,7 @@ def export_results_to_data_library(gi, history_id, lib_id, allowed_error_states)
                 if ds_in_coll['object']['name'] is not None:
                     
                     # Get dataset object for the collection element
-                    dataset = gi.datasets.show_dataset(ds_in_coll['id'])
+                    dataset = gi.datasets.show_dataset(ds_in_coll['object']['id'])
                     file_path = dataset['file_name']
                     
                     uploaded_dataset = gi.libraries.upload_from_galaxy_filesystem(lib_id, file_path, folder_id=folder_id, link_data_only="copy_files", tag_using_filenames=True)


### PR DESCRIPTION
Adding support for results to be directly uploaded to galaxy datalib, 

adds `--do-not-download-results` option to skip downloading of the results

ToDo: Adding support for data collection to be uploaded to datalib: Done